### PR TITLE
fix: Simplify PATH setup with clear user instructions

### DIFF
--- a/ubuntu/24.04/wizard.sh
+++ b/ubuntu/24.04/wizard.sh
@@ -91,28 +91,6 @@ install_command() {
     log_info "Installed $SCRIPT_NAME to $target_script"
 }
 
-# Update PATH if necessary
-update_path() {
-    if [[ "$INSTALL_DIR" == "$USER_HOME/.local/bin" ]]; then
-        # Check if ~/.local/bin is in PATH
-        if [[ ":$PATH:" != *":$USER_HOME/.local/bin:"* ]]; then
-            log_step "Adding $USER_HOME/.local/bin to PATH..."
-            
-            # Add to .bashrc
-            if [[ -f "$USER_HOME/.bashrc" ]]; then
-                echo "" >> "$USER_HOME/.bashrc"
-                echo "# Added by claude-sandbox installer" >> "$USER_HOME/.bashrc"
-                echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$USER_HOME/.bashrc"
-                log_info "Added PATH export to $USER_HOME/.bashrc"
-            fi
-            
-            # Apply PATH changes to current shell session immediately
-            export PATH="$USER_HOME/.local/bin:$PATH"
-            log_info "PATH updated for current session - claude-sandbox is now available"
-        fi
-    fi
-}
-
 
 # Build Docker image
 build_docker_image() {
@@ -159,7 +137,18 @@ show_summary() {
     echo ""
     
     if [[ "$INSTALL_DIR" == "$USER_HOME/.local/bin" ]]; then
-        echo "✅ claude-sandbox command is ready to use immediately!"
+        echo "⚠️  PATH Setup Required:"
+        echo "   Step 1: Try reloading your shell configuration"
+        echo "   source ~/.profile"
+        echo ""
+        echo "   Step 2: Test if the command works"
+        echo "   claude-sandbox --help"
+        echo ""
+        echo "   Step 3: If the command is still not found, add to ~/.bashrc and reload:"
+        echo "   echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc"
+        echo "   source ~/.bashrc"
+        echo ""
+        echo "   Alternative: Restart your terminal instead of using 'source'"
     fi
     
     echo ""
@@ -195,8 +184,7 @@ uninstall() {
         rm -f "$target_script"
         log_info "Removed $target_script"
     fi
-    
-    
+
     log_info "Claude Sandbox uninstalled successfully"
 }
 
@@ -245,7 +233,6 @@ main() {
     check_privileges
     check_prerequisites
     install_command
-    update_path
     build_docker_image
     show_summary
 }


### PR DESCRIPTION
## Summary
- Remove complex `update_path()` function that couldn't work due to shell process limitations
- Provide step-by-step instructions for users to manually configure PATH
- Simplify installation flow by removing automatic PATH manipulation attempts

## Problem
The wizard script was attempting to automatically set PATH within a child shell process, which fundamentally cannot affect the parent shell. This led to users needing to manually run `source ~/.profile` after installation.

## Solution
Replace the complex automatic PATH setup with clear, step-by-step user instructions:
1. First try `source ~/.profile` (leverages Ubuntu's default ~/.local/bin setup)
2. Test the command works
3. If not, add explicit export to ~/.bashrc and reload
4. Alternative option to restart terminal

## Changes
- **Removed**: `update_path()` function (22 lines)
- **Simplified**: Installation flow by removing PATH manipulation
- **Added**: Clear step-by-step PATH setup instructions for users
- **Improved**: User experience with explicit guidance instead of hidden complexity

## Test Plan
- [x] Script syntax validation (`bash -n wizard.sh`)
- [x] Help command functionality (`./wizard.sh --help`)
- [x] Installation flow simplified and working

🤖 Generated with [Claude Code](https://claude.ai/code)